### PR TITLE
Better way to detect license acceptance.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -173,6 +173,13 @@ execute "#{splunk_cmd} enable boot-start --accept-license --answer-yes" do
   end
 end
 
+# ftr = first time run file created by a splunk install
+execute "accept_license" do
+	command "#{splunk_cmd} enable boot-start --accept-license --answer-yes"
+  action :run
+  only_if { File.exists?("#{splunk_dir}/ftr") }
+end
+
 splunk_password = node['splunk']['auth'].split(':')[1]
 execute "Changing Admin Password" do
   command "#{splunk_cmd} edit user admin -password #{splunk_password} -roles admin -auth admin:changeme && echo true > /opt/splunk_setup_passwd"


### PR DESCRIPTION
The "--accept-license" argument checks for #{splunk_dir}/ftr and deletes it when you accept the license.

The "boot-start" argument causes splunk to create the /etc/init.d/splunk script and set it to start on boot.